### PR TITLE
Added patch for eigen bug 1086, to support new SuiteSparse

### DIFF
--- a/patches/bug1086_SuiteSparse_UF_long.patch
+++ b/patches/bug1086_SuiteSparse_UF_long.patch
@@ -1,0 +1,40 @@
+# HG changeset patch
+# User Gael Guennebaud <g.gael@free.fr>
+# Date 1444659612 -7200
+# Node ID 6996ab297dedb4684a708e23cee3002906a4ef1c
+# Parent  73a8f4213cd4790bac8d1d7440a2f9e05ad0d3f8
+Bug 1086: replace deprecated UF_long by SuiteSparse_long
+
+diff --git a/Eigen/src/CholmodSupport/CholmodSupport.h b/Eigen/src/CholmodSupport/CholmodSupport.h
+--- a/Eigen/src/CholmodSupport/CholmodSupport.h
++++ b/Eigen/src/CholmodSupport/CholmodSupport.h
+@@ -78,7 +78,7 @@
+   {
+     res.itype = CHOLMOD_INT;
+   }
+-  else if (internal::is_same<_Index,UF_long>::value)
++  else if (internal::is_same<_Index,SuiteSparse_long>::value)
+   {
+     res.itype = CHOLMOD_LONG;
+   }
+diff --git a/Eigen/src/SPQRSupport/SuiteSparseQRSupport.h b/Eigen/src/SPQRSupport/SuiteSparseQRSupport.h
+--- a/Eigen/src/SPQRSupport/SuiteSparseQRSupport.h
++++ b/Eigen/src/SPQRSupport/SuiteSparseQRSupport.h
+@@ -47,7 +47,7 @@
+  * You can then apply it to a vector.
+  * 
+  * R is the sparse triangular factor. Use matrixQR() to get it as SparseMatrix.
+- * NOTE : The Index type of R is always UF_long. You can get it with SPQR::Index
++ * NOTE : The Index type of R is always SuiteSparse_long. You can get it with SPQR::Index
+  * 
+  * \tparam _MatrixType The type of the sparse matrix A, must be a column-major SparseMatrix<>
+  * NOTE
+@@ -59,7 +59,7 @@
+   public:
+     typedef typename _MatrixType::Scalar Scalar;
+     typedef typename _MatrixType::RealScalar RealScalar;
+-    typedef UF_long Index ; 
++    typedef SuiteSparse_long Index ;
+     typedef SparseMatrix<Scalar, ColMajor, Index> MatrixType;
+     typedef PermutationMatrix<Dynamic, Dynamic> PermutationType;
+   public:


### PR DESCRIPTION
Apply a tweaked version of the the patch in eigen ticket 1086:

http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1086

to solve the UF_fact that long doesn't exist in newer versions of SuiteSparse.
