### PR TITLE
DM-11902: use CMake installer to ensure we install everything

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,8 +1,13 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
+config()
+{
+    (rm -rf build && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..)
+}
+
 build()
 {
-	(mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make)
+	(cd build && make)
 }
 
 install()

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,18 +1,13 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
+build()
+{
+	(mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make)
+}
+
 install()
 {
-	#
-	# Eigen uses cmake, but fortunately the scripts are easy enough to
-	# emulate w/o having to have cmake as a dependency
-	#
-
 	clean_old_install
-
-	mkdir -p "$PREFIX/include/unsupported"
-	cp -r Eigen "$PREFIX/include"
-	cp -r unsupported/Eigen "$PREFIX/include/unsupported"
-	ln -fs "$PREFIX/include/Eigen/Core" "$PREFIX/include/Eigen/Core.h"
-
+	(cd build && make install)
 	install_ups
 }

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -9,5 +9,6 @@ install()
 {
 	clean_old_install
 	(cd build && make install)
+    (cd $PREFIX/include && ln -s eigen3/* .)
 	install_ups
 }


### PR DESCRIPTION
Since LSST expects to do:
```
#include "Eigen/Core"
```
instead of 
```
#include "eigen3/Eigen/Core"
```
(which seems to be the way Eigen expects to be used) I also added symlinks from the eigen3 subdirectory back to the root include directory.