### PR TITLE
DM-22817: Disable eigen testing

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,7 +2,7 @@
 
 config()
 {
-    (rm -rf build && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..)
+    (rm -rf build && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF ..)
 }
 
 build()


### PR DESCRIPTION
Testing sometimes gets confused by trying to find the wrong Boost.